### PR TITLE
add moveLiveRegion function to keep live regions within <md-autocomplete>

### DIFF
--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -1142,7 +1142,9 @@ function MdDialogProvider($$interimElementProvider) {
           for (var i = 0; i < children.length; i++) {
             // skip over child if it is an ascendant of the dialog
             // or a script or style tag
-            if (element !== children[i] && !isNodeOneOf(children[i], ['SCRIPT', 'STYLE'])) {
+            if (element !== children[i] &&
+             !isNodeOneOf(children[i], ['SCRIPT', 'STYLE']) &&
+             !children[i].hasAttribute('aria-live')) {
               children[i].setAttribute('aria-hidden', isHidden);
             }
           }

--- a/src/components/dialog/dialog.spec.js
+++ b/src/components/dialog/dialog.spec.js
@@ -1708,6 +1708,23 @@ describe('$mdDialog', function() {
       expect(sibling.attr('aria-hidden')).toBe('true');
     }));
 
+    it('should not apply aria-hidden to live region siblings', inject(function($mdDialog, $rootScope, $timeout) {
+
+      var template = '<md-dialog aria-label="Some Other Thing">Hello</md-dialog>';
+      var parent = angular.element('<div>');
+      parent.append('<div aria-live="polite"></div>')
+
+      $mdDialog.show({
+        template: template,
+        parent: parent
+      });
+
+      runAnimation();
+
+      var liveRegion = angular.element(parent[0].querySelector('[aria-live]'));
+      expect(liveRegion.attr('aria-hidden')).toBe(undefined);
+    }));
+
     it('should trap focus inside of the dialog', function() {
       var template = '<md-dialog>Hello <input></md-dialog>';
       var parent = document.createElement('div');


### PR DESCRIPTION
Fixes https://github.com/angular/material/issues/10804

Adds a function (called on init) to the autocompleteController.js that moves the component's live region to be inside the md-autocomplete element. This fixes a bug where autocompletes within dialogs were hidden with aria-hidden="true", since they were not a direct ancestor of the dialog.

The fix works because it guarantees that aria-hidden will not be applied to the live region for the autocomplete being created within the dialog.